### PR TITLE
Add Coinprism to the URL whitelist

### DIFF
--- a/signer/config.json
+++ b/signer/config.json
@@ -6,7 +6,9 @@
                 "https://[\\w\\.-]+\\.mytrezor\\.com(/.*)?",
                 "https://trezor\\.github\\.io(/.*)?",
                 "https://greenaddress\\.it(/.*)?",
-                "https://[\\w\\.-]+\\.greenaddress\\.it(/.*)?"
+                "https://[\\w\\.-]+\\.greenaddress\\.it(/.*)?",
+                "https://coinprism\\.com(/.*)?",
+                "https://[\\w\\.-]+\\.coinprism\\.com(/.*)?"
 	],
 	"blacklist_urls": [
 	],


### PR DESCRIPTION
The coinprism.com domain name needs to be whitelisted, otherwise the TREZOR won't accept calls coming from Coinprism.