### PR TITLE
Adding hidraw for raw HID access

### DIFF
--- a/udev/51-trezor-udev.rules
+++ b/udev/51-trezor-udev.rules
@@ -6,6 +6,7 @@
 
 # TREZOR
 SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="dialout"
 
 # TREZOR Raspberry Pi Shield
 SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea80", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"


### PR DESCRIPTION
This rule is for allowing Chrome's HID API to work with Trezor on Linux