### PR TITLE
Add Quroum Wallet to the URL whitelist

### DIFF
--- a/signer/config.json
+++ b/signer/config.json
@@ -10,7 +10,9 @@
 		"https://coinprism\\.com(/.*)?",
 		"https://[\\w\\.-]+\\.coinprism\\.com(/.*)?",
 		"https://bitex\\.la(/.*)?",
-		"https://[\\w\\.-]+\\.bitex\\.la(/.*)?"
+		"https://[\\w\\.-]+\\.bitex\\.la(/.*)?",
+		"https://quorumwallet\\.com(/.*)?",
+		"https://[\\w\\.-]+\\.quorumwallet\\.com(/.*)?"
 		],
 	"blacklist_urls": [
 	],


### PR DESCRIPTION
Quorum is an Ethereum wallet, which supports message signing features of Trezor to authorize transactions. See more on [Reddit](https://www.reddit.com/r/ethereum/comments/498ltg/quorum_using_bitcoin_hardware_wallets_to_secure/) or in [this blog post](https://medium.com/@alexberegszaszi/quorum-using-bitcoin-keys-with-ethereum-ad44cf28fb20).

The currently uploaded site doesn't include Trezor support as it won't work due to URL restrictions.

The reason I've included `http` next to `https` is:
- it is a fully client side wallet
- Ethereum RPC nodes do not support `https` at the moment. A tunnel/proxy needs to be used. Many users prefer to use their own nodes, but won't have `https` support.

Let me know if this is acceptable