### PR TITLE
RFC: Ethereum support (GetEthereumAddress and SignEthereumTx)

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -592,6 +592,7 @@ message TxAck {
 /**
  * Request: Ask device to sign transaction
  * All fields are optional from the protocol's point of view. Each field defaults to value `0` if missing.
+ * Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
  * @next PassphraseRequest
  * @next PinMatrixRequest
  * @next EthereumTxRequest
@@ -599,11 +600,11 @@ message TxAck {
  */
 message EthereumSignTx {
 	repeated uint32 address_n = 1;			// BIP-32 path to derive the key from master node
-	optional bytes nonce = 2;			// 256 bit unsigned big endian
-	optional bytes gas_price = 3;			// 256 bit unsigned big endian (in wei)
-	optional bytes gas_limit = 4;			// 256 bit unsigned big endian
+	optional bytes nonce = 2;			// <=256 bit unsigned big endian
+	optional bytes gas_price = 3;			// <=256 bit unsigned big endian (in wei)
+	optional bytes gas_limit = 4;			// <=256 bit unsigned big endian
 	optional bytes to = 5;				// 160 bit address hash
-	optional bytes value = 6;			// 256 bit unsigned big endian (in wei)
+	optional bytes value = 6;			// <=256 bit unsigned big endian (in wei)
 	optional bytes data_initial_chunk = 7;		// The initial data chunk (<= 1024 bytes)
 	optional uint32 data_length = 8;		// Length of transaction payload
 }
@@ -611,15 +612,15 @@ message EthereumSignTx {
 /**
  * Response: Device asks for more data from transaction payload, or returns the signature.
  * If data_length is set, device awaits that many more bytes of payload.
- * Otherwise, the signature_* fields contain the computed transaction signature.
+ * Otherwise, the signature_* fields contain the computed transaction signature. All three fields will be present.
  * @prev EthereumSignTx
  * @next EthereumTxAck
  */
 message EthereumTxRequest {
-	optional uint32 data_length = 1;		// Number of bytes being requested
+	optional uint32 data_length = 1;		// Number of bytes being requested (<= 1024)
 	optional uint32 signature_v = 2;		// Computed signature (recovery parameter, limited to 27 or 28)
-	optional bytes signature_r = 3;			// Computed signature
-	optional bytes signature_s = 4;			// Computed signature
+	optional bytes signature_r = 3;			// Computed signature R component (256 bit)
+	optional bytes signature_s = 4;			// Computed signature S component (256 bit)
 }
 
 /**
@@ -628,7 +629,7 @@ message EthereumTxRequest {
  * @next EthereumTxRequest
  */
 message EthereumTxAck {
-	optional bytes data_chunk = 1;			// Bytes from transaction payload
+	optional bytes data_chunk = 1;			// Bytes from transaction payload (<= 1024 bytes)
 }
 
 ///////////////////////

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -604,7 +604,8 @@ message EthereumSignTx {
 	optional bytes gas_limit = 4;			// 256 bit unsigned big endian
 	optional bytes to = 5;				// 160 bit address hash
 	optional bytes value = 6;			// 256 bit unsigned big endian (in wei)
-	optional uint32 data_length = 7;		// Length of transaction payload
+	optional bytes data_initial_chunk = 7;		// The initial data chunk (<= 1024 bytes)
+	optional uint32 data_length = 8;		// Length of transaction payload
 }
 
 /**

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -64,6 +64,11 @@ enum MessageType {
 	MessageType_SignIdentity = 53 [(wire_in) = true];
 	MessageType_SignedIdentity = 54 [(wire_out) = true];
 	MessageType_GetFeatures = 55 [(wire_in) = true];
+	MessageType_EthereumGetAddress = 56 [(wire_in) = true];
+	MessageType_EthereumAddress = 57 [(wire_out) = true];
+	MessageType_EthereumSignTx = 58 [(wire_in) = true];
+	MessageType_EthereumTxRequest = 59 [(wire_out) = true];
+	MessageType_EthereumTxAck = 60 [(wire_in) = true];
 	MessageType_DebugLinkDecision = 100 [(wire_debug_in) = true];
 	MessageType_DebugLinkGetState = 101 [(wire_debug_in) = true];
 	MessageType_DebugLinkState = 102 [(wire_debug_out) = true];
@@ -282,11 +287,30 @@ message GetAddress {
 }
 
 /**
+ * Request: Ask device for Ethereum address corresponding to address_n path
+ * @next PassphraseRequest
+ * @next EthereumAddress
+ * @next Failure
+ */
+message EthereumGetAddress {
+	repeated uint32 address_n = 1;			// BIP-32 path to derive the key from master node
+	optional bool show_display = 2;			// optionally show on display before sending the result
+}
+
+/**
  * Response: Contains address derived from device private seed
  * @prev GetAddress
  */
 message Address {
 	required string address = 1;		// Coin address in Base58 encoding
+}
+
+/**
+ * Response: Contains an Ethereum address derived from device private seed
+ * @prev EthereumGetAddress
+ */
+message EthereumAddress {
+	required bytes address = 1;		// Coin address as an Ethereum 160 bit hash
 }
 
 /**
@@ -563,6 +587,47 @@ message TxRequest {
  */
 message TxAck {
 	optional TransactionType tx = 1;
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * All fields are optional from the protocol's point of view. Each field defaults to value `0` if missing.
+ * @next PassphraseRequest
+ * @next PinMatrixRequest
+ * @next EthereumTxRequest
+ * @next Failure
+ */
+message EthereumSignTx {
+	repeated uint32 address_n = 1;			// BIP-32 path to derive the key from master node
+	optional bytes nonce = 2;			// 256 bit unsigned big endian
+	optional bytes gas_price = 3;			// 256 bit unsigned big endian (in wei)
+	optional bytes gas_limit = 4;			// 256 bit unsigned big endian
+	optional bytes to = 5;				// 160 bit address hash
+	optional bytes value = 6;			// 256 bit unsigned big endian (in wei)
+	optional uint32 data_length = 7;		// Length of transaction payload
+}
+
+/**
+ * Response: Device asks for more data from transaction payload, or returns the signature.
+ * If data_length is set, device awaits that many more bytes of payload.
+ * Otherwise, the signature_* fields contain the computed transaction signature.
+ * @prev EthereumSignTx
+ * @next EthereumTxAck
+ */
+message EthereumTxRequest {
+	optional uint32 data_length = 1;		// Number of bytes being requested
+	optional uint32 signature_v = 2;		// Computed signature (recovery parameter, limited to 27 or 28)
+	optional bytes signature_r = 3;			// Computed signature
+	optional bytes signature_s = 4;			// Computed signature
+}
+
+/**
+ * Request: Transaction payload data.
+ * @prev EthereumTxRequest
+ * @next EthereumTxRequest
+ */
+message EthereumTxAck {
+	optional bytes data_chunk = 1;			// Bytes from transaction payload
 }
 
 ///////////////////////


### PR DESCRIPTION
This is purely an RFC to discuss what would be the preferred way to implement Ethereum support.

**Quick intro into Ethereum:**

**0)** It uses only uncompressed public keys

**1)** An address is formatted as:
- Take the Keccak (pre-NIST SHA3) hash of the x and y points of the uncompressed key (i.e. remove the type field (0x04 for uncompressed) of the SEC1 format)
- Take the 160 least significant bits
- Use the hex string representation of the result

Albeit this is the format used internally and by all clients, there exist a backward compatible checksumming for the hex representation. Additionally several other address formats/proposals exist.

**2)** Ethereum is based on account state and not UTXOs. This results in a very simple transaction format, which includes the recipient, value and additional fields signed by the sender address. Technically it is the following fields, in this order, serialized using RLP:
- `nonce`
- `gasPrice`
- `gasLimit`
- `to`
- `value`
- `data`
- `v`
- `r`
- `s`

Where `nonce`, `gasPrice`, `gasLimit` and `value` are 256 bit big endian numbers, `data` is an optional arbitrary length field, `to` is the recipient address (as a binary and not as a hex string) and `v`/`r`/`s` correspond to the signature fields. 

**The proposal: address retrieval**

Based on how different the address format is, a new method `GetEthereumAddress` with its return value `EthereumAddress` is proposed.

I am not sure that this is the best way. Alternatively a field can be introduced in the `CoinType` to distinguish between Bitcoin-style and Ethereum-style addresses (sample implementation here: https://github.com/keepkey/device-protocol/pull/3) and use `GetAddress`.

The Ethereum address format is subject to change hence I am bit worried which option to take.

**The proposal: transaction signing**

Again, as transactions have no similarity to Bitcoin, this proposes an entirely different format.

Request:
```
message EthereumSignTx {
        repeated uint32 address_n = 1;		// BIP-32 path to derive the key from master node
        required bytes nonce = 2;
        required string to = 3;
        required bytes value = 4;               // 256-bit number (big endian)
        optional bytes data = 5;
        required bytes gasPrice = 6;            // 256-bit number (big endian)
        optional bytes gasLimit = 7;            // 256-bit number (big endian)
}
```

Response:
```
message EthereumSignedTx {
	required bytes rlp = 1;
}
```

Remarks:
- `gasLimit` is optional and defaults to `21000` (note: I should add it to the proto)
- The user must be presented on screen with the recipient, total transaction cost (`value + (gasPrice * gasLimit)`) and some representation of the `data` field.
- The `data` field behaves like `OP_RETURN` for transactions between *external accounts*, but is used as the ABI field (mostly method invocation) when transacting with *contract accounts*. A future improvement to this protocol could be moving the ABI encoding to the device instead in addition to the `data` field.

Some questions:

1) What is the preferred way for address generation?
2) How to handle non-negative 256 bit big number fields? As `bytes` or differently?
3) The `nonce` must be incremental. One can publish future transactions to the *mempool* by leaving a gap. Should the firmware take care about nonces?
