### PR TITLE
Matrix Recovery

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -387,6 +387,8 @@ message RecoveryDevice {
 	optional string language = 4 [default='english'];	// device language
 	optional string label = 5;				// device label
 	optional bool enforce_wordlist = 6;			// enforce BIP-39 wordlist during the process
+	// 7 reserved for keepkey recovery method
+	optional uint32 type = 8;				// supported recovery type (see RecoveryType)
 }
 
 /**
@@ -396,6 +398,7 @@ message RecoveryDevice {
  * @prev WordAck
  */
 message WordRequest {
+	optional WordRequestType type = 1;
 }
 
 /**

--- a/protob/types.proto
+++ b/protob/types.proto
@@ -105,6 +105,32 @@ enum PinMatrixRequestType {
 }
 
 /**
+ * Type of recovery procedure. These should be used as bitmask, e.g.,
+ * `RecoveryDeviceType_ScrambledWords | RecoveryDeviceType_Matrix`
+ * listing every method supported by the host computer.
+ *
+ * Note that ScrambledWords must be supported by every implementation
+ * for backward compatibility; there is no way to not support it.
+ *
+ * @used_in RecoveryDevice
+ */
+enum RecoveryDeviceType {
+	RecoveryDeviceType_ScrambledWords = 0; // words in scrambled order.
+	RecoveryDeviceType_Matrix = 1;         // matrix recovery type.
+	// use powers of twp when extending this field
+}
+
+/**
+ * Type of Recovery Word request
+ * @used_in WordRequest
+ */
+enum WordRequestType {
+	WordRequestType_Plain = 0;
+	WordRequestType_Matrix9 = 1;
+	WordRequestType_Matrix6 = 2;
+}
+
+/**
  * Structure representing BIP32 (hierarchical deterministic) node
  * Used for imports of private key into the device and exporting public key out of device
  * @used_in PublicKey


### PR DESCRIPTION
This is the communication part of my matrix recovery patch.  It adds two new optional fields to the existing protocol messages for recovery:
- In message `RecoveryDevice` the enum `RecoveryDeviceType` is added.  This is a way for the PC to tell the Trezor which recovery type it prefers.  If this is not set it defaults to the old scrambled words mechanism that every PC must support for backward compatibility.
- In message `WordAck` there is a new field WordRequestType that is set by Trezor.  If the PC indicated support for matrix recovery, TREZOR asks for Matrix9 or Matrix6 requests instead of word requests and then expects instead of a word a string containing a single digit (corresponding to the matrix element).  Thus, the Trezor decides which recovery method to use and it does so using this field.  An old Trezor will not set the field indicating a plain word request.

The protocol is designed such that it is fully backward compatible.  An old PC client can recover a new Trezor and a new PC client can recover an old Trezor without any complicated protocol detection. **Question**: Should we make the field RecoveryDeviceType a bit-field, so that the PC can explicitly state which recovery methods it supports?  Or do we assume the PC will always support all methods up to the method that it indicates as the preferred?  

See issue trezor/trezor-mcu#96 for a description of matrix recovery.
