### PR TITLE
Steem integration

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -854,14 +854,15 @@ message SteemOperationTransfer {
 }
 
 message SteemSignTx {
-	required uint32 ref_block_num = 1;
-	required uint32 ref_block_prefix = 2;
-	required uint32 expiration = 3;
+	repeated uint32 pubkey_n = 1;			// BIP-32 path to derive the key from master node
+	required uint32 ref_block_num = 2;
+	required uint32 ref_block_prefix = 3;
+	required uint32 expiration = 4;
 	// Instead of using a "repeated enum" we restrict
 	// trezor to single-operation transactions
 	// and pick one out of the following ops:
-	optional SteemOperationTransfer transfer = 4;
-	optional SteemOperationAccountUpdate account_update = 5;
+	optional SteemOperationTransfer transfer = 5;
+	optional SteemOperationAccountUpdate account_update = 6;
 }
 
 message SteemTxSignature {
@@ -870,7 +871,7 @@ message SteemTxSignature {
 }
 
 message SteemGetPublicKey {
-	repeated uint32 address_n = 1;	// BIP-32 path to derive the key from master node
+	repeated uint32 pubkey_n = 1;	// BIP-32 path to derive the key from master node
 	optional bool show_display = 2;	// optionally show on display before sending the result
 }
 

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -77,6 +77,10 @@ enum MessageType {
 	MessageType_SteemTxSignature = 66 [(wire_out) = true];
 	MessageType_SteemSignTx = 67 [(wire_in) = true];
 	MessageType_SteemOperationTransfer = 68 [(wire_in) = true];
+	MessageType_SteemOperationAccountUpdate = 69 [(wire_in) = true];
+	MessageType_SteemPermission = 70 [(wire_in) = true];
+	MessageType_SteemAccountAccountAuth = 71 [(wire_in) = true];
+	MessageType_SteemAccountKeyAuth = 72 [(wire_in) = true];
 
 	MessageType_DebugLinkDecision = 100 [(wire_debug_in) = true];
 	MessageType_DebugLinkGetState = 101 [(wire_debug_in) = true];
@@ -816,6 +820,31 @@ message DebugLinkFlashErase {
 /**
  * Steem related message
  */
+message SteemAccountKeyAuth {
+	required bytes pubkey = 1;
+	required uint32 weight = 2; // uint16
+}
+
+message SteemAccountAccountAuth {
+	required string account = 1;
+	required uint32 weight = 2; // uint16
+}
+
+message SteemPermission {
+	required uint32 weight_threshold = 1;
+	repeated SteemAccountAccountAuth account_auths = 2;
+	repeated SteemAccountKeyAuth key_auths = 3;
+}
+
+message SteemOperationAccountUpdate {
+	required string account = 1;
+	required bytes memo_key = 2;
+	required string json_metadata = 3;
+	optional SteemPermission owner = 4;
+	optional SteemPermission active = 5;
+	optional SteemPermission posting = 6;
+}
+
 message SteemOperationTransfer {
 	required string from = 1;
 	required string to = 2;
@@ -832,6 +861,7 @@ message SteemSignTx {
 	// trezor to single-operation transactions
 	// and pick one out of the following ops:
 	optional SteemOperationTransfer transfer = 4;
+	optional SteemOperationAccountUpdate account_update = 5;
 }
 
 message SteemTxSignature {

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -72,6 +72,12 @@ enum MessageType {
 	MessageType_GetECDHSessionKey = 61 [(wire_in) = true];
 	MessageType_ECDHSessionKey = 62 [(wire_out) = true];
 	MessageType_SetU2FCounter = 63 [(wire_in) = true];
+	MessageType_SteemPublicKey = 64 [(wire_out) = true];
+	MessageType_SteemGetPublicKey = 65 [(wire_in) = true];
+	MessageType_SteemTxSignature = 66 [(wire_out) = true];
+	MessageType_SteemSignTx = 67 [(wire_in) = true];
+	MessageType_SteemOperationTransfer = 68 [(wire_in) = true];
+
 	MessageType_DebugLinkDecision = 100 [(wire_debug_in) = true];
 	MessageType_DebugLinkGetState = 101 [(wire_debug_in) = true];
 	MessageType_DebugLinkState = 102 [(wire_debug_out) = true];
@@ -805,4 +811,39 @@ message DebugLinkMemoryWrite {
  */
 message DebugLinkFlashErase {
 	optional uint32 sector = 1;
+}
+
+/**
+ * Steem related message
+ */
+message SteemOperationTransfer {
+	required string from = 1;
+	required string to = 2;
+	required int64 amount = 3;
+	required string asset = 4;
+	optional string memo = 5;
+}
+
+message SteemSignTx {
+	required uint32 ref_block_num = 1;
+	required uint32 ref_block_prefix = 2;
+	required uint32 expiration = 3;
+	// Instead of using a "repeated enum" we restrict
+	// trezor to single-operation transactions
+	// and pick one out of the following ops:
+	optional SteemOperationTransfer transfer = 4;
+}
+
+message SteemTxSignature {
+	required bytes signature = 1; // FIXME: why optional?
+	optional bytes digest = 2;
+}
+
+message SteemGetPublicKey {
+	repeated uint32 address_n = 1;	// BIP-32 path to derive the key from master node
+	optional bool show_display = 2;	// optionally show on display before sending the result
+}
+
+message SteemPublicKey {
+	required bytes pubkey = 1;
 }


### PR DESCRIPTION
This pull requests adds the basic Steem messages to trezor-common.

The trezor can be called with `SteemGetPublicKey` and `SteemSignTx` and either returns the PublicKey or a Signature message.
The `SteemSignTx` has an optional field for carring `transfers` for now only, but we will add more operation types over time. 
Since the used version of nanopb does not support `OneOf`, we decided to go with `optional` keywords and restrict ourselves to transactions that only carry **a single operation** even though the protocol/blockchain could deal with more.

These Operations are Steem specific and BitShares messages will be added separately when we get there. Some code will look similar.
