### PR TITLE
Add null to allow electron apps

### DIFF
--- a/signer/config.json
+++ b/signer/config.json
@@ -15,7 +15,8 @@
 		"https://[\\w\\.-]+\\.bitex\\.la(/.*)?",
 		"https://quorumwallet\\.com(/.*)?",
 		"https://[\\w\\.-]+\\.quorumwallet\\.com(/.*)?",
-		"chrome-extension://jcjjhjgimijdkoamemaghajlhegmoclj(/.*)?"
+		"chrome-extension://jcjjhjgimijdkoamemaghajlhegmoclj(/.*)?",
+		"null"
 		],
 	"blacklist_urls": [
 	],


### PR DESCRIPTION
Electron discussion there

https://github.com/electron/electron/issues/7931 

It seems `Origin: 'null'` from electron apps is a feature, not a bug