### PR TITLE
Ethereum: chain id for EIP-155 replay protection

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -622,6 +622,7 @@ message EthereumSignTx {
 	optional bytes value = 6;			// <=256 bit unsigned big endian (in wei)
 	optional bytes data_initial_chunk = 7;		// The initial data chunk (<= 1024 bytes)
 	optional uint32 data_length = 8;		// Length of transaction payload
+	optional uint32 chain_id = 9;			// Chain Id for EIP 155
 }
 
 /**


### PR DESCRIPTION
Added a field chain_id.  To get a backwards compatible signature
this field should not be set.  Otherwise it should be set to the
EIP-155 chain id.  Currently only chain id between 1 and 109 are
supported.
see trezor/trezor-mcu#142.