### PR TITLE
Raising the maxfee

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -2,7 +2,7 @@
 	"coin_name": "Bitcoin",
 	"coin_shortcut": "BTC",
 	"address_type": 0,
-	"maxfee_kb": 100000,
+	"maxfee_kb": 300000,
 	"address_type_p2sh": 5,
 	"address_type_p2wpkh": 6,
 	"address_type_p2wsh": 10,


### PR DESCRIPTION
Right now, the recommended fee by 21.co is 200 satoshis per b. (see https://bitcoinfees.21.co/api/v1/fees/recommended )

We use 21.co on mytrezor.

200 satoshis per byte == 200.000 satoshis per kB.

I am raising it to 300.000 so we have some breathing room.