### PR TITLE
Altcoin support in GetPublicKey

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -271,6 +271,7 @@ message GetPublicKey {
 	repeated uint32 address_n = 1;		// BIP-32 path to derive the key from master node
 	optional string ecdsa_curve_name = 2;	// ECDSA curve name to use
 	optional bool show_display = 3;		// optionally show on display before sending the result
+	optional string coin_name = 4 [default='Bitcoin'];
 }
 
 /**

--- a/protob/types.proto
+++ b/protob/types.proto
@@ -166,6 +166,8 @@ message CoinType {
 	optional uint32 address_type_p2wpkh = 6 [default=6];
 	optional uint32 address_type_p2wsh = 7 [default=10];
 	optional string signed_message_header = 8;
+	optional uint32 xpub_magic = 9 [default=0x0488b21e];
+	optional uint32 xprv_magic = 10 [default=0x0488ade4];
 }
 
 /**


### PR DESCRIPTION
Added `xpub_magic` and `xprv_magic` fields to the `CoinType` structure  and `coin_name` to `GetPublicKey` message structure