### PR TITLE
Adding regtest to coins.json

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -38,6 +38,24 @@
 	"dust_limit": 546,
 	"blocktime_minutes": 10
 }, {
+	"coin_name": "Regtest",
+	"coin_shortcut": "REGTEST",
+	"address_type": 111,
+	"address_type_p2sh": 196,
+	"maxfee_kb": 10000000,
+	"minfee_kb": 1000,
+	"signed_message_header": "Bitcoin Signed Message:\n",
+	"hash_genesis_block": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+	"xpub_magic": "043587cf",
+	"xprv_magic": "04358394",
+	"bip44": 1,
+	"segwit": true,
+	"default_fee_b": {
+		"Normal": 10
+	},
+	"dust_limit": 546,
+	"blocktime_minutes": 10
+}, {
 	"coin_name": "Namecoin",
 	"coin_shortcut": "NMC",
 	"address_type": 52,


### PR DESCRIPTION
I am not entirely sure if this is a good idea or not :/

It would help me a bit in some edge-case testing in wallet, but it's not 100% needed. 

It's basically the same as TEST, just with different genesis blockhash (which is used only in wallet AFAIK).