### PR TITLE
Allow testing recovery with an initialized device

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -395,6 +395,7 @@ message RecoveryDevice {
 	// 7 reserved for unused recovery method
 	optional uint32 type = 8;				// supported recovery type (see RecoveryType)
 	optional uint32 u2f_counter = 9;			// U2F counter
+	optional bool dry_run = 10;				// perform dry-run recovery workflow (for safe mnemonic validation)
 }
 
 /**


### PR DESCRIPTION
This would allow safe mnemonic validation by using a dry-run flag (see https://github.com/trezor/trezor-mcu/issues/59).