### PR TITLE
udev compat with all major linux distros

### DIFF
--- a/udev/51-trezor.rules
+++ b/udev/51-trezor.rules
@@ -2,18 +2,16 @@
 # https://trezor.io/
 # Put this file into /usr/lib/udev/rules.d
 
-# Raspbian does not understand the new TAG+="uaccess", TAG+="udev-acl" syntax, use MODE+GROUP for now ... :-(
-
 # TREZOR
-SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
-KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 # TREZOR v2
-SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c0", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c1", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
-KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c0",  MODE="0666", GROUP="dialout"
-KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c1",  MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c0", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c1", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c0",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c1",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 # TREZOR Raspberry Pi Shield
-SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea80", MODE="0666", GROUP="dialout", SYMLINK+="trezor%n"
-KERNEL=="hidraw*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea80",  MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea80", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea80",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
Virtually no linux distirbutions rely on the 'dialout' group anymore. Some older distros still use the "plugdev" group but most have been switching to a convention of using udev tags for device permissions instead.

This should avoid users having to create a group, add themseves to it, and logout/login. Plugdev group method still in place for backwards compat. Won't hurt anything.

I have been modifying this by hand for multiple systems of mine and others. Finally decided to PR it.