### PR TITLE
Adding Bitcoin 2X

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -282,5 +282,34 @@
 	"min_address_length": 35,
 	"max_address_length": 95,
 	"bitcore": []
-}
-]
+}, {
+	"coin_name": "Bitcoin",
+	"coin_shortcut": "BTC",
+	"coin_label": "Bitcoin Segwit2x",
+	"address_type": 0,
+	"address_type_p2sh": 5,
+	"maxfee_kb": 500000,
+	"minfee_kb": 1000,
+	"signed_message_header": "Bitcoin Signed Message:\n",
+	"hash_genesis_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+	"xpub_magic": "0488b21e",
+	"xprv_magic": "0488ade4",
+	"bip44": 157,
+	"segwit": true,
+	"forkid": null,
+	"default_fee_b": {
+		"Low": 10,
+		"Economy": 70,
+		"Normal": 140,
+		"High": 200
+	},
+	"dust_limit": 546,
+	"blocktime_minutes": 10,
+	"firmware": null,
+	"address_prefix": "bitcoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": [
+		"https://2x-bitcore4.trezor.io"
+	]
+}]


### PR DESCRIPTION
We will probably need b2x for mytrezor + connect in coins.json.

This is an idea, how to do it.

I realize, that having "B2X" is problematic, because there is no such thing as "only sending B2X" because of the lack of replay protection.

However, it's also problematic to have two currencies, both with "BTC".

And doing "BC1" and "BC2" would complicate everything even more. So I don't know how to get out of this.