### PR TITLE
Add *.unchained-capital.com to domain whitelist

### DIFF
--- a/signer/config.json
+++ b/signer/config.json
@@ -16,6 +16,7 @@
 		"https://dash\\.run(/.*)?",
 		"https://[\\w\\.-]+\\.dash\\.run(/.*)?",
 		"https://0xproject\\.com(/.*)?",
+		"https://[\\w\\.-]+\\.unchained-capital\\.com(/.*)?",
 		"chrome-extension://jcjjhjgimijdkoamemaghajlhegmoclj(/.*)?"
 		],
 	"blacklist_urls": [


### PR DESCRIPTION
Our website (https://www.unchained-capital.com) uses trezor.js to

* embed interactions with Trezor devices into our application's workflows
* support multiple coins, testnets and our own custom transaction types and BIP32 derivation paths
* prevent leaking any information about our transactions to third parties (including trezor.io) before broadcasting them to their blockchains

For these reasons, we were unable to use TrezorConnect.

Thanks for your great work.  We love our Trezors!