### PR TITLE
Add Fujicoin support

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -398,5 +398,34 @@
 	"bitcore": [
 		"https://mona.chainsight.info"
 	]
+},
+{
+	"coin_name": "Fujicoin",
+	"coin_shortcut": "FJC",
+	"address_type": 36,
+	"address_type_p2sh": 16,
+	"maxfee_kb": 1000000,
+	"minfee_kb": 100000,
+	"signed_message_header": "FujiCoin Signed Message:\n",
+	"hash_genesis_block": "adb6d9cfd74075e7f91608add4bd2a2ea636f70856183086842667a1597714a0",
+	"xpub_magic": "0488b21e",
+	"xprv_magic": "0488ade4",
+	"bech32_prefix": null,
+	"bip44": 75,
+	"segwit": false,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Normal": 100000
+	},
+	"dust_limit": 100000,
+	"blocktime_minutes": 1.0,
+	"firmware": "stable",
+	"address_prefix": "fujicoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": [
+		"http://explorer.fujicoin.org/"
+	]
 }
 ]


### PR DESCRIPTION
Please add Fujicoin to TREZOR's firmware.
We already have electrum-FJC (v 2.9.3) to Fujicoin users.
You can download from the following URL.
http://www.fujicoin.org/downloads.php

Thanks,
motty
