### PR TITLE
Add null to config, to fix chrome apps + electron + nw.js

### DIFF
--- a/signer/config.json
+++ b/signer/config.json
@@ -17,7 +17,7 @@
 		"https://[\\w\\.-]+\\.dash\\.run(/.*)?",
 		"https://0xproject\\.com(/.*)?",
 		"https://[\\w\\.-]+\\.unchained-capital\\.com(/.*)?",
-		"chrome-extension://jcjjhjgimijdkoamemaghajlhegmoclj(/.*)?"
+		"null"
 		],
 	"blacklist_urls": [
 	],


### PR DESCRIPTION
Rehashing PR #20 

Chrome apps, Electron apps, nw.js apps set origin as "null". For that reason, our own password manager stopped working with bridge.

We originally merged #20 but reverted it for security issues. I think now it's time to merge it, since nw.js apps require this, and Copay will on desktop work as nw.js app only.