### PR TITLE
Vertcoin support

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -439,5 +439,34 @@
 	"bitcore": [
 		"http://explorer.fujicoin.org/"
 	]
+},
+{
+	"coin_name": "Vertcoin",
+	"coin_shortcut": "VTC",
+	"coin_label": "Vertcoin",
+	"address_type": 71,
+	"address_type_p2sh": 5,
+	"maxfee_kb": 40000000,
+	"minfee_kb": 100000,
+	"signed_message_header": "Vertcoin Signed Message:\n",
+	"hash_genesis_block": "4d96a915f49d40b1e5c2844d1ee2dccb90013a990ccea12c492d22110489f0c4",
+	"xprv_magic": "0488ade4",
+	"xpub_magic": "0488b21e",
+	"xpub_magic_segwit_p2sh": "049d7cb2",
+	"bech32_prefix": "vtc",
+	"bip44": 28,
+	"segwit": true,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Normal": 1000
+	},
+	"dust_limit": 54600,
+	"blocktime_minutes": 2.5,
+	"firmware": "stable",
+	"address_prefix": "vertcoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": []
 }
 ]


### PR DESCRIPTION
I looked at what we need for Vertcoin support and it's really not that much.  I'm not sure about minfee/maxfee/dust limit setting.  All other settings should be okay (I copied the genesis hex from the full node sources, hope this is correct).  Vertcoin uses the same 3... addresses as bitcoin for P2SH.

Of course, you need to increase the coin count in trezor-mcu when this is added.

It's possible to use it with electrum, see https://github.com/vertcoin/electrum-vtc/pull/47.