### PR TITLE
[Stellar] [WIP] Add protobuf messages to support Stellar

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -99,6 +99,31 @@ enum MessageType {
 	MessageType_DebugLinkMemory = 111 [(wire_debug_out) = true];
 	MessageType_DebugLinkMemoryWrite = 112 [(wire_debug_in) = true];
 	MessageType_DebugLinkFlashErase = 113 [(wire_debug_in) = true];
+
+	// Stellar
+	MessageType_StellarGetPublicKey = 200 [(wire_in) = true];
+	MessageType_StellarPublicKey = 201 [(wire_out) = true];
+
+	MessageType_StellarSignTx = 202 [(wire_in) = true];
+	MessageType_StellarTxOpRequest = 203 [(wire_out) = true];
+	MessageType_StellarSignMessage = 204 [(wire_in) = true];
+	MessageType_StellarMessageSignature = 205 [(wire_out) = true];
+	MessageType_StellarVerifyMessage = 206 [(wire_in) = true];
+
+	MessageType_StellarCreateAccountOp = 210 [(wire_in) = true];
+	MessageType_StellarPaymentOp = 211 [(wire_in) = true];
+	MessageType_StellarPathPaymentOp = 212 [(wire_in) = true];
+	MessageType_StellarManageOfferOp = 213 [(wire_in) = true];
+	MessageType_StellarCreatePassiveOfferOp = 214 [(wire_in) = true];
+	MessageType_StellarSetOptionsOp = 215 [(wire_in) = true];
+	MessageType_StellarChangeTrustOp = 216 [(wire_in) = true];
+	MessageType_StellarAllowTrustOp = 217 [(wire_in) = true];
+	MessageType_StellarAccountMergeOp = 218 [(wire_in) = true];
+	// Omitted: inflation is not a supported operation, would be 219
+	MessageType_StellarManageDataOp = 220 [(wire_in) = true];
+	MessageType_StellarBumpSequenceOp = 221 [(wire_in) = true];
+
+	MessageType_StellarSignedTx = 230 [(wire_out) = true];
 }
 
 ////////////////////
@@ -967,6 +992,278 @@ message CosiSign {
 message CosiSignature {
 	optional bytes signature = 1;		// Signature
 }
+
+//////////////////////
+// Stellar messages //
+//////////////////////
+
+/**
+ * Request: Public key at the specified index
+ * @next StellarPublicKey
+ */
+message StellarGetPublicKey {
+	repeated uint32 address_n = 1;	// BIP-32 path. For compatibility with other wallets, must be m/44'/148'/index'
+}
+
+/**
+ * Response: Public key for the given index
+ * @prev StellarGetPublicKey
+ */
+message StellarPublicKey {
+	optional bytes public_key = 1;	// Raw bytes of the public key (no version or checksum)
+}
+
+/**
+ * Request: ask device to sign the given string
+ * @next StellarMessageSignature
+ */
+message StellarSignMessage {
+	repeated uint32 address_n = 1;	// BIP-32 path. For compatibility with other wallets, must be m/44'/148'/index'
+
+	optional string message = 2;	// Message to sign
+}
+
+/**
+ * Response: device has signed data
+ * @prev StellarSignMessage
+ */
+message StellarMessageSignature {
+	optional bytes public_key = 1;	// Raw bytes of the public key (no version or checksum)
+	optional bytes signature = 2;   // ed25519 signature bytes
+}
+
+/**
+ * Request: ask device to verify that signature is valid (public_key has signed message)
+ * @next Success
+ * @next Failure
+ */
+message StellarVerifyMessage {
+	optional bytes public_key = 1;	// Public key corresponding to the private key that signed the message
+	optional bytes message = 2;		// Binary data that was signed
+	optional bytes signature = 3;	// Signature to verify
+}
+
+/**
+ * Request: ask device to sign Stellar transaction
+ * @next StellarTxOpRequest
+ */
+message StellarSignTx {
+	optional uint32 protocol_version = 1;	// version of the protofbuf messaging protocol the client is using
+	repeated uint32 address_n = 2;			// BIP-32 path. For compatibility with other wallets, must be m/44'/148'/index'
+	optional string network_passphrase = 3; // passphrase for signing messages on the destination network
+	optional bytes source_account = 4;		// 32-byte source
+	optional uint32 fee = 5;				// Fee (in stroops) for the transaction
+	optional uint64 sequence_number = 6;	// transaction sequence number
+	optional uint32 timebounds_start = 8;	// unix timestamp (client must truncate this to 32 bytes)
+	optional uint32 timebounds_end = 9;	    // unix timestamp (client must truncate this to 32 bytes)
+	optional uint32 memo_type = 10;			// 0 = none, 1 = text, 2 = id, 3 = hash, 4 = return
+	optional string memo_text = 11;			// up to 28 characters (4 bytes are for length)
+	optional uint64 memo_id = 12;			// 8-byte uint64
+	optional bytes memo_hash = 13;			// 32 bytes representing a hash
+	optional uint32 num_operations = 14;	// number of operations in this transaction
+}
+
+/**
+ * Response: device is ready for client to send the next operation
+ * @prev StellarSignTx
+ * @next StellarPaymentOp
+ * @next StellarCreateAccountOp
+ * @next StellarPathPaymentOp
+ * @next StellarManageOfferOp
+ * @next StellarCreatePassiveOfferOp
+ * @next StellarSetOptionsOp
+ * @next StellarChangeTrustOp
+ * @next StellarAllowTrustOp
+ * @next StellarAccountMergeOp
+ * @next StellarManageDataOp
+ * @next StellarBumpSequenceOp
+ */
+message StellarTxOpRequest {
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarPaymentOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional bytes destination_account = 2;	// 32-byte destination account
+	optional StellarAssetType asset = 3;	// asset involved in the operation
+	optional int64 amount = 4;				// amount of the given asset to pay
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarCreateAccountOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional bytes new_account = 2;			// 32-byte account ID to create
+	optional int64 starting_balance = 3;	// initial starting balance for the new account
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarPathPaymentOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional StellarAssetType send_asset = 2;
+	optional int64 send_max = 3;
+	optional bytes destination_account = 4;
+	optional StellarAssetType destination_asset = 5;
+	optional int64 destination_amount = 6;
+	repeated StellarAssetType paths = 7;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarManageOfferOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional StellarAssetType selling_asset = 2;
+	optional StellarAssetType buying_asset = 3;
+	optional int64 amount = 4;
+	optional uint32 price_n = 5;			// Price numerator
+	optional uint32 price_d = 6;			// Price denominator
+	optional uint64 offer_id = 7;			// Offer ID for updating an existing offer
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarCreatePassiveOfferOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional StellarAssetType selling_asset = 2;
+	optional StellarAssetType buying_asset = 3;
+	optional int64 amount = 4;
+	optional uint32 price_n = 5;			// Price numerator
+	optional uint32 price_d = 6;			// Price denominator
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarSetOptionsOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional bytes inflation_destination_account = 2; // (optional) 32-byte inflation destination
+	optional uint32 clear_flags = 3;
+	optional uint32 set_flags = 4;
+	optional uint32 master_weight = 5;
+	optional uint32 low_threshold = 6;
+	optional uint32 medium_threshold = 7;
+	optional uint32 high_threshold = 8;
+	optional string home_domain = 9;
+	optional uint32 signer_type = 10;
+	optional bytes signer_key = 11;
+	optional uint32 signer_weight = 12;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarChangeTrustOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional StellarAssetType asset = 2;
+	optional uint64 limit = 3;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarAllowTrustOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional bytes trusted_account = 2;		// The account being allowed to hold the asset
+	optional uint32 asset_type = 3;			// 1 = 4-character, 2 = 12-character
+	optional string asset_code = 4;			// human-readable asset code
+	optional uint32 is_authorized = 5;
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarAccountMergeOp {
+	optional bytes source_account = 1;		// (optional) 32-byte source account
+
+	optional bytes destination_account = 2; // 32-byte destination account
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarManageDataOp {
+	optional bytes source_account = 1;	// (optional) 32-byte source account
+
+	optional string key = 2;
+	optional bytes value = 3;			// 64 bytes of arbitrary data
+}
+
+/**
+ * Request: ask device to confirm this operation type
+ * @prev StellarTxOpRequest
+ * @next StellarTxOpRequest
+ * @next StellarSignedTx
+ */
+message StellarBumpSequenceOp {
+	optional bytes source_account = 1;	// (optional) 32-byte source account
+
+	optional uint64 bump_to = 2;		// new sequence number
+}
+
+/**
+ * Response: signature for transaction
+ * @prev StellarPaymentOp
+ * @prev StellarCreateAccountOp
+ * @prev StellarPathPaymentOp
+ * @prev StellarManageOfferOp
+ * @prev StellarCreatePassiveOfferOp
+ * @prev StellarSetOptionsOp
+ * @prev StellarChangeTrustOp
+ * @prev StellarAllowTrustOp
+ * @prev StellarAccountMergeOp
+ * @prev StellarManageDataOp
+ * @prev StellarBumpSequenceOp
+ */
+message StellarSignedTx {
+	optional bytes public_key = 1;  // public key for the private key used to sign data
+	optional bytes signature = 2;   // signature suitable for sending to the Stellar network
+}
+
 
 /////////////////////////////////////////////////////////////
 // Debug messages (only available if DebugLink is enabled) //

--- a/protob/types.proto
+++ b/protob/types.proto
@@ -444,3 +444,13 @@ enum NEMImportanceTransferMode {
 	ImportanceTransfer_Activate = 1;
 	ImportanceTransfer_Deactivate = 2;
 }
+
+/**
+ * Describes a Stellar asset
+ * @used_in StellarTxOpAck
+ */
+message StellarAssetType {
+	optional uint32 type = 1;	// 0 = native asset (XLM), 1 = alphanum 4, 2 = alphanum 12
+	optional string code = 2;	// for non-native assets, string describing the code
+	optional bytes issuer = 3;	// 32-byte issuing address
+}


### PR DESCRIPTION
Adds protobuf messages used by related trezor-mcu and python-trezor PRs.

See the trezor-mcu PR for more details: https://github.com/trezor/trezor-mcu/pull/259