### PR TITLE
Add protobuf syntax tag

### DIFF
--- a/protob/config.proto
+++ b/protob/config.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 /**
  * Configuration format for TREZOR plugin
  */

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 /**
  * Messages for TREZOR communication
  */

--- a/protob/storage.proto
+++ b/protob/storage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 /**
  * Storage area of TREZOR
  */

--- a/protob/types.proto
+++ b/protob/types.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 /**
  * Types for TREZOR communication
  *


### PR DESCRIPTION
Add syntax tag to the protobuf files to remove warning message.
```
protoc -I/usr/include -I. config.proto -o config.pb
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: config.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
protoc -I/usr/include -I. messages.proto -o messages.pb
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: messages.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: types.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
protoc -I/usr/include -I. storage.proto -o storage.pb
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: storage.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: types.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
protoc -I/usr/include -I. types.proto -o types.pb
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: types.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```