### PR TITLE
Add Terracoin (TRC) to coins.json

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -527,5 +527,38 @@
 	"min_address_length": 35,
 	"max_address_length": 35,
 	"bitcore": []
+},
+{
+	"coin_name": "Terracoin",
+	"coin_shortcut": "TRC",
+	"coin_label": "Terracoin",
+	"curve_name": "secp256k1",
+	"address_type": 0,
+	"address_type_p2sh": 5,
+	"maxfee_kb": 100000,
+	"minfee_kb": 10000,
+	"signed_message_header": "DarkCoin Signed Message:\n",
+	"hash_genesis_block": "00000000804bbc6a621a9dbb564ce469f492e1ccf2d70f8a6b241e26a277afa2",
+	"xprv_magic": "0488ade4",
+	"xpub_magic": "0488b21e",
+	"xpub_magic_segwit_p2sh": null,
+	"bech32_prefix": null,
+	"bip44": 0,
+	"segwit": false,
+	"decred": false,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Normal": 10
+	},
+	"dust_limit": 5460,
+	"blocktime_minutes": 2,
+	"firmware": "stable",
+	"address_prefix": "terracoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": [
+		"https://insight.terracoin.io"
+	]
 }
 ]


### PR DESCRIPTION
Pull request to add Terracoin (TRC), https://terracoin.io/, to Trezor.

The Insight server is hosted at https://insight.terracoin.io/status.

Double checked the parameters of Terracoin, hope all of them all correct.

Hope this all that is needed to get TRC successfully added to Trezor.