### PR TITLE
coins: add litecoin testnet

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -202,6 +202,39 @@
 	]
 },
 {
+	"coin_name": "Litecoin Testnet",
+	"coin_shortcut": "TLTC",
+	"coin_label": "Litecoin Testnet",
+	"curve_name": "secp256k1",
+	"address_type": 111,
+	"address_type_p2sh": 58,
+	"maxfee_kb": 40000000,
+	"minfee_kb": 1000,
+	"signed_message_header": "Litecoin Signed Message:\n",
+	"hash_genesis_block": "4966625a4b2851d9fdee139e56211a0d88575f59ed816ff5e6a63deb4e3e29a0",
+	"xprv_magic": "04358394",
+	"xpub_magic": "043587cf",
+	"xpub_magic_segwit_p2sh": null,
+	"bech32_prefix": "tltc",
+	"bip44": 1,
+	"segwit": true,
+	"decred": false,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Normal": 10
+	},
+	"dust_limit": 54600,
+	"blocktime_minutes": 2.5,
+	"firmware": "stable",
+	"address_prefix": "litecoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": [
+		"https://testnet.litecore.io"
+	]
+},
+{
 	"coin_name": "Dogecoin",
 	"coin_shortcut": "DOGE",
 	"coin_label": "Dogecoin",


### PR DESCRIPTION
Hi, I'd like to add support for the Litecoin Testnet. I hope I did this correctly.
`xpub_magic_segwit_p2sh` is not defined in slip-0132 yet, so I left it null.
Also, the Litecoin project is in the middle of a relay fee reduction (it's in the master branch of their repo), but it's not widely deployed yet. That is why the testnet `minfee_kb` is lower than mainnet LTC.