### PR TITLE
Add Zcoin support

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -543,5 +543,42 @@
 	"min_address_length": 35,
 	"max_address_length": 35,
 	"bitcore": []
+},
+{
+	"coin_name": "Zcoin",
+	"coin_shortcut": "XZC",
+	"coin_label": "Zcoin",
+	"curve_name": "secp256k1",
+	"address_type": 82,
+	"address_type_p2sh": 7,
+	"maxfee_kb": 1000000,
+	"minfee_kb": 0,
+	"signed_message_header": "Zcoin Signed Message:\n",
+	"hash_genesis_block": "4381deb85b1b2c9843c222944b616d997516dcbd6a964e1eaf0def0830695233",
+	"xprv_magic": "0488ade4",
+	"xpub_magic": "0488b21e",
+	"xpub_magic_segwit_p2sh": null,
+	"bech32_prefix": null,
+	"cashaddr_prefix": null,
+	"bip44": 136,
+	"segwit": false,
+	"decred": false,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Low": 1,
+		"Economy": 10,
+		"Normal": 100,
+		"High": 200
+	},
+	"dust_limit": 546,
+	"blocktime_minutes": 10,
+	"firmware": "stable",
+	"address_prefix": "zcoin:",
+	"min_address_length": 27,
+	"max_address_length": 34,
+	"bitcore": [
+		"https://insight.zcoin.io"
+	]
 }
 ]

--- a/coins.json
+++ b/coins.json
@@ -580,5 +580,40 @@
 	"bitcore": [
 		"https://insight.zcoin.io"
 	]
+},
+{
+	"coin_name": "Zcoin Testnet",
+	"coin_shortcut": "tXZC",
+	"coin_label": "Zcoin Testnet",
+	"curve_name": "secp256k1",
+	"address_type": 65,
+	"address_type_p2sh": 178,
+	"maxfee_kb": 1000000,
+	"minfee_kb": 0,
+	"signed_message_header": "Zcoin Signed Message:\n",
+	"hash_genesis_block": "7ac038c193c2158c428c59f9ae0c02a07115141c6e9dc244ae96132e99b4e642",
+	"xprv_magic": "04358394",
+	"xpub_magic": "043587cf",
+	"xpub_magic_segwit_p2sh": null,
+	"bech32_prefix": null,
+	"cashaddr_prefix": null,
+	"bip44": 1,
+	"segwit": false,
+	"decred": false,
+	"forkid": null,
+	"force_bip143": false,
+	"default_fee_b": {
+		"Low": 1,
+		"Economy": 10,
+		"Normal": 100,
+		"High": 200
+	},
+	"dust_limit": 546,
+	"blocktime_minutes": 10,
+	"firmware": "debug",
+	"address_prefix": "testzcoin:",
+	"min_address_length": 27,
+	"max_address_length": 35,
+	"bitcore": []
 }
 ]


### PR DESCRIPTION
Allows signing transactions with [Electrum-XZC](https://github.com/zcoinofficial/electrum-xzc/releases) or together with https://github.com/trezor/python-trezor/pull/219 via command line as described at https://github.com/yura-pakhuchiy/trezor-mcu/blob/zcoin/Zcoin.md

https://insight.zcoin.io supports websockets and should work with https://wallet.trezor.io if coins.json will be updated on wallet server.

Many thanks to @sn-ntu and @Technoprenerd for zcoin port of insight server. It is pre-requirement for coin integration.