### PR TITLE
Added txtype as optional field in preparation of Wanchain support

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -688,6 +688,7 @@ message EthereumSignTx {
 	optional bytes data_initial_chunk = 7;		// The initial data chunk (<= 1024 bytes)
 	optional uint32 data_length = 8;		// Length of transaction payload
 	optional uint32 chain_id = 9;			// Chain Id for EIP 155
+	optional bytes txtype = 10;			// <=256 bit unsigned big endian
 }
 
 /**


### PR DESCRIPTION
As requested by @jhoenicke and @prusnak added txtype to EthereumSignTx in preparation of adding Wanchain support