### PR TITLE
proto: add `auto_lock_delay_ms` field to ApplySettings and Features

### DIFF
--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -175,6 +175,7 @@ message ApplySettings {
 	optional bool use_passphrase = 3;
 	optional bytes homescreen = 4;
 	optional PassphraseSourceType passphrase_source = 5;
+	optional uint32 auto_lock_delay_ms = 6;
 }
 
 /**

--- a/protob/storage.proto
+++ b/protob/storage.proto
@@ -29,4 +29,5 @@ message Storage {
 	optional uint32 flags = 13;			// device flags
 	optional HDNodeType u2froot = 14;		// U2F root node
 	optional bool unfinished_backup = 15;		// seed was improperly backed up
+	optional uint32 auto_lock_delay_ms = 16;	// configurable auto-lock delay (in milliseconds)
 }


### PR DESCRIPTION
Following https://github.com/trezor/trezor-core/issues/163 (I am planning to add [this feature](https://github.com/romanz/trezor-mcu/tree/auto-lock) to TREZOR One).