### PR TITLE
mod fujicoin SegWit

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -459,16 +459,19 @@
 	"hash_genesis_block": "adb6d9cfd74075e7f91608add4bd2a2ea636f70856183086842667a1597714a0",
 	"xpub_magic": "0488b21e",
 	"xprv_magic": "0488ade4",
-	"xpub_magic_segwit_p2sh": null,
-	"bech32_prefix": null,
+	"xpub_magic_segwit_p2sh": "049d7cb2",
+	"bech32_prefix": "fc",
 	"cashaddr_prefix": null,
 	"bip44": 75,
-	"segwit": false,
+	"segwit": true,
 	"decred": false,
 	"forkid": null,
 	"force_bip143": false,
 	"default_fee_b": {
-		"Normal": 100000
+		"Low": 100000,
+		"Economy": 200000,
+		"Normal": 500000,
+		"High": 1000000
 	},
 	"dust_limit": 100000,
 	"blocktime_minutes": 1.0,


### PR DESCRIPTION
Fujicoin has completed activation of SegWit. Please merge this pull request.

We updated electrum-FJC to support SegWit and confirmed remittance with Bech32 SegWit address.
Electrum-FJC is available from official website.
http://www.fujicoin.org/downloads.php
Please support fujicoin in firmware. Then test by electrum-FJC by all means.

Thanks,
Motty
fujicoin.org
