### PR TITLE
Fix Lisk potobuf messages

### DIFF
--- a/protob/types.proto
+++ b/protob/types.proto
@@ -479,9 +479,9 @@ message LiskTransactionCommon {
 	optional uint64 amount = 2 [default=0];
 	optional uint64 fee = 3;
 	optional string recipient_id = 4;
-	optional string sender_public_key = 5;
-	optional string requester_public_key = 6;
-	optional string signature = 7;
+	optional bytes sender_public_key = 5;
+	optional bytes requester_public_key = 6;
+	optional bytes signature = 7;
 	optional uint32 timestamp = 8;
 	optional LiskTransactionAsset asset = 9;
 }

--- a/protob/types.proto
+++ b/protob/types.proto
@@ -476,8 +476,8 @@ enum LiskTransactionType {
 */
 message LiskTransactionCommon {
 	optional LiskTransactionType type = 1;
-	optional string amount = 2 [default='0'];
-	optional string fee = 3;
+	optional uint64 amount = 2 [default=0];
+	optional uint64 fee = 3;
 	optional string recipient_id = 4;
 	optional string sender_public_key = 5;
 	optional string requester_public_key = 6;


### PR DESCRIPTION
Change `amount` and `fee` from `string` to `uint64`
Change `sender_public_key`, `requester_public_key` and `singature` from `string` to `bytes`
