### PR TITLE
Fix chainid for Ethereum Social

### DIFF
--- a/defs/ethereum/networks.json
+++ b/defs/ethereum/networks.json
@@ -30,6 +30,12 @@
     "url": "https://ubiqsmart.com"
   },
   {
+    "chain_id": 28,
+    "shortcut": "ETSC",
+    "name": "Ethereum Social",
+    "url": "https://ethereumsocial.kr"
+  },
+  {
     "chain_id": 30,
     "shortcut": "RSK",
     "name": "Rootstock",
@@ -58,12 +64,6 @@
     "shortcut": "tETC",
     "name": "Ethereum Classic Testnet",
     "url": "https://ethereumclassic.github.io"
-  },
-  {
-    "chain_id": 1128,
-    "shortcut": "ETSC",
-    "name": "Ethereum Social",
-    "url": "https://ethereumsocial.kr"
   },
   {
     "chain_id": 1987,


### PR DESCRIPTION
We've already used 28 for chainid and 1128 is reserved for the hw path so fixing it 😄 

https://github.com/kvhnuke/etherwallet/blob/mercury/app/scripts/nodes.js#L251