### PR TITLE
Change URL for Bitcore (Monacoin).

### DIFF
--- a/coins.json
+++ b/coins.json
@@ -458,7 +458,7 @@
 	"min_address_length": 27,
 	"max_address_length": 34,
 	"bitcore": [
-		"https://mona.chainsight.info"
+		"https://mona.insight.monaco-ex.org"
 	]
 },
 {

--- a/defs/coins/monacoin.json
+++ b/defs/coins/monacoin.json
@@ -33,7 +33,7 @@
   "min_address_length": 27,
   "max_address_length": 34,
   "bitcore": [
-    "https://mona.chainsight.info"
+    "https://mona.insight.monaco-ex.org"
   ],
   "blockbook": []
 }


### PR DESCRIPTION
mona.chainsight.info is not maintained well and it cannot handle SegWit transactions.
Newer URL can handle them.