### PR TITLE
Add groestlcoin testnet native segwit header

### DIFF
--- a/defs/coins/groestlcoin_testnet.json
+++ b/defs/coins/groestlcoin_testnet.json
@@ -15,7 +15,7 @@
   "xprv_magic": 70615956,
   "xpub_magic": 70617039,
   "xpub_magic_segwit_p2sh": 71979618,
-  "xpub_magic_segwit_native": null,
+  "xpub_magic_segwit_native": 73342198,
   "bech32_prefix": "tgrs",
   "cashaddr_prefix": null,
   "slip44": 1,


### PR DESCRIPTION
In light of the fact that this value should not remain null, add the P2WPKH header to complete Groestlcoin testnet.