### PR TITLE
Adding testnet to wallet support

### DIFF
--- a/defs/support.json
+++ b/defs/support.json
@@ -50,7 +50,8 @@
 		"Dash": true,
 		"Litecoin": true,
 		"Zcash": true,
-		"Testnet": true
+		"Testnet": true,
+		"Zcash Testnet": true
 	},
 	"electrum": {
 		"Bitcoin": "https://electrum.org/",


### PR DESCRIPTION
We want to support testnet in wallet, even when they are not in the list on the left.