### PR TITLE
Update networks.json - tRSK slip44

### DIFF
--- a/defs/ethereum/networks.json
+++ b/defs/ethereum/networks.json
@@ -65,7 +65,7 @@
   },
   {
     "chain_id": 31,
-    "slip44": 1,
+    "slip44": 37310,
     "shortcut": "tRSK",
     "name": "RSK Testnet",
     "rskip60": true,


### PR DESCRIPTION
Using **specific testnets _slip-44_ ids** allows _rskip-60_ checksum implementation in `EthereumGetAddress`.