### PR TITLE
Using new FW for BGold

### DIFF
--- a/defs/support.json
+++ b/defs/support.json
@@ -8,7 +8,7 @@
 		"Dogecoin": "1.5.2",
 		"Dash": "1.5.2",
 		"Zcash": "1.6.2",
-		"Bgold": "1.6.0",
+		"Bgold": "1.6.2",
 		"DigiByte": "1.6.0",
 		"Monacoin": "1.6.0",
 		"Fujicoin": "1.6.1",


### PR DESCRIPTION
In current FW and current wallet, we wrongly use "Bitcoin" coin name for BGold.

Only in new firmware we accept "BGold" as coin name, so I bumped the version here