### PR TITLE
Update version group id of Koto

### DIFF
--- a/defs/coins/koto.json
+++ b/defs/coins/koto.json
@@ -23,7 +23,7 @@
   "decred": false,
   "fork_id": null,
   "force_bip143": false,
-  "version_group_id": null,
+  "version_group_id": 48748912,
   "default_fee_b": {
     "Normal": 10
   },


### PR DESCRIPTION
We have reverted SigHash personalization and updated version group id.
Koto Overwinter does not yet activated. We will release new Overwinter-compliant Koto in near future.
Could you re-enable Koto?