### PR TITLE
Ethersocial Network(ESN) support added

### DIFF
--- a/defs/ethereum/networks.json
+++ b/defs/ethereum/networks.json
@@ -126,5 +126,13 @@
     "name": "EtherGem",
     "rskip60": false,
     "url": "https://egem.io"
+  },
+  {
+    "chain_id": 31102,
+    "slip44": 31102,
+    "shortcut": "ESN",
+    "name": "Ethersocial Network",
+    "rskip60": false,
+    "url": "https://ethersocial.org"
   }
 ]


### PR DESCRIPTION
Add Ethersocial Network support.
- bitcointalk ANN : https://bitcointalk.org/index.php?topic=3126487.20
- homepage https://ethersocial.org or https://ethersocialnetwork.com
- Official Block explorer https://ethersocial.net
  - Network hashrate chart : https://ethersocial.net/stats/hashrate
- Unofficial netstat https://escstats.gonsmine.com
- MyCrypto PR https://github.com/MyCryptoHQ/MyCrypto/pull/1881
- MyEtherwallet PR (in progress) https://github.com/kvhnuke/etherwallet/pull/1879
- slip0044 index : 31102 (https://github.com/satoshilabs/slips/pull/277 )
- chainId : 31102 
