### PR TITLE
Fix typo for Ethereum Social [ETSC]

### DIFF
--- a/tools/coins_details.py
+++ b/tools/coins_details.py
@@ -236,7 +236,7 @@ def update_ethereum(details):
     out = details['coins'].setdefault('coin2:ETSC', {})
     out['type'] = 'coin'
     set_default(out, 'shortcut', 'ETSC')
-    set_default(out, 'name', 'EthereumSocial')
+    set_default(out, 'name', 'Ethereum Social')
     set_default(out, 't1_enabled', 'yes')
     set_default(out, 't2_enabled', 'yes')
     update_marketcap(out, 'etsc')


### PR DESCRIPTION
We use Ethereum Social for our coin name instead of EthereumSocial