### PR TITLE
Tezos: field updates

### DIFF
--- a/protob/messages-tezos.proto
+++ b/protob/messages-tezos.proto
@@ -5,6 +5,15 @@ option java_package = "com.satoshilabs.trezor.lib.protobuf";
 option java_outer_classname = "TrezorMessageTezos";
 
 /**
+ * Tezos Curve Type
+ */
+enum TezosCurveType {
+    Ed25519 = 0;
+    Secp256k1 = 1;
+    P256 = 2;
+}
+
+/**
  * Request: Ask device for Tezos address corresponding to address_n path
  * @start
  * @next TezosAddress
@@ -12,7 +21,8 @@ option java_outer_classname = "TrezorMessageTezos";
  */
 message TezosGetAddress {
     repeated uint32 address_n = 1;      // BIP-32 path to derive the key from master node
-    optional bool show_display = 2;     // optionally show on display before sending the result
+    optional TezosCurveType curve = 2 [default=Ed25519];  // Curve to use in trezor
+    optional bool show_display = 3;     // optionally show on display before sending the result
 }
 
 /**
@@ -30,7 +40,8 @@ message TezosAddress {
  */
 message TezosGetPublicKey {
     repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
-    optional bool show_display = 2;         // Optionally show on display before sending the result
+    optional TezosCurveType curve = 2 [default=Ed25519];  // Curve to use in trezor
+    optional bool show_display = 3;         // Optionally show on display before sending the result
 }
 
 /**
@@ -38,7 +49,7 @@ message TezosGetPublicKey {
  * @end
  */
 message TezosPublicKey {
-    optional bytes public_key = 1;          // Tezos public key
+    optional string public_key = 1;          // b58 encoded Tezos public key with prefix
 }
 
 /**
@@ -48,68 +59,77 @@ message TezosPublicKey {
  */
 message TezosSignTx {
     repeated uint32 address_n = 1;                  // BIP-32 path to derive the key from master node
-    optional TezosOperationCommon operation = 2;    // Tezos operation structure
-    optional TezosTransactionType transaction = 3;  // Tezos transaction part
-    optional TezosOriginationType origination = 4;  // Tezos origination part
-    optional TezosDelegationType delegation = 5;    // Tezos delegation part
+    optional TezosCurveType curve = 2 [default=Ed25519];  // Curve to use in trezor
+    optional bytes branch = 3;                      // b58 encoded branch with prefix
+
+    optional TezosRevealOp reveal = 4;              // Tezos reveal operation (may be bundled with other op)
+    optional TezosTransactionOp transaction = 5;    // Tezos transaction operation
+    optional TezosOriginationOp origination = 6;    // Tezos origination operation
+    optional TezosDelegationOp delegation = 7;      // Tezos delegation operation
     /*
-    * Tezos contract ID
-    */
+     * Tezos contract ID
+     */
     message TezosContractID {
         optional TezosContractType tag = 1;
         optional bytes hash = 2;                    // Implicit = 21B, originated = 20B + 1B padding
         /*
-        * Type of Tezos Contract type
-        */
+         * Type of Tezos Contract type
+         */
         enum TezosContractType {
             Implicit = 0;
             Originated = 1;
         }
     }
-    /*
-     * Structure representing the common part for Tezos operations
+    /**
+     * Structure representing information for reveal
      */
-    message TezosOperationCommon {
-        optional bytes branch = 1;
-        optional TezosOperationType tag = 2;
-        optional TezosContractID source = 3;
-        optional uint64 fee = 4;
-        optional uint64 counter = 5;
-        optional uint64 gas_limit = 6;
-        optional uint64 storage_limit = 7;
-        /*
-        * Type of Tezos operation
-        */
-        enum TezosOperationType {
-            Transaction = 8;
-            Origination = 9;
-            Delegation = 10;
-        }
+    message TezosRevealOp {
+        optional TezosContractID source = 1;
+        optional uint64 fee = 2;
+        optional uint64 counter = 3;
+        optional uint64 gas_limit = 4;
+        optional uint64 storage_limit = 5;
+        optional bytes public_key = 6;
     }
-    /*
-     * Structure representing additional information for transaction
+    /**
+     * Structure representing information for transaction
      */
-    message TezosTransactionType {
-        optional uint64 amount = 1;
-        optional TezosContractID destination = 2;
-        optional bytes parameters = 3;
+    message TezosTransactionOp {
+        optional TezosContractID source = 1;
+        optional uint64 fee = 2;
+        optional uint64 counter = 3;
+        optional uint64 gas_limit = 4;
+        optional uint64 storage_limit = 5;
+        optional uint64 amount = 6;
+        optional TezosContractID destination = 7;
+        optional bytes parameters = 8;
     }
-    /*
-    * Structure representing additional information for origination
-    */
-    message TezosOriginationType {
-        optional bytes manager_pubkey = 1;
-        optional uint64 balance = 2;
-        optional bool spendable = 3;
-        optional bool delegatable = 4;
-        optional bytes delegate = 5;        // 1B tag + 20B public key hash
-        optional bytes script = 6;
+    /**
+     * Structure representing information for origination
+     */
+    message TezosOriginationOp {
+        optional TezosContractID source = 1;
+        optional uint64 fee = 2;
+        optional uint64 counter = 3;
+        optional uint64 gas_limit = 4;
+        optional uint64 storage_limit = 5;
+        optional bytes manager_pubkey = 6;
+        optional uint64 balance = 7;
+        optional bool spendable = 8;
+        optional bool delegatable = 9;
+        optional bytes delegate = 10;
+        optional bytes script = 11;
     }
-    /*
-    * Structure representing additional information for delegation
-    */
-    message TezosDelegationType {
-        optional bytes delegate = 1;        // 1B tag + 20B public key hash
+    /**
+     * Structure representing information for delegation
+     */
+    message TezosDelegationOp {
+        optional TezosContractID source = 1;
+        optional uint64 fee = 2;
+        optional uint64 counter = 3;
+        optional uint64 gas_limit = 4;
+        optional uint64 storage_limit = 5;
+        optional bytes delegate = 6;
     }
 }
 
@@ -118,7 +138,7 @@ message TezosSignTx {
  * @end
  */
 message TezosSignedTx {
-    optional bytes signature = 1;           // Tezos transaction signature
-    optional bytes sig_op_contents = 2;     // Signed operation contents
-    optional string operation_hash = 3;     // b58 check encoded blake2b hashed operation contents
+    optional string signature = 1;          // Tezos b58 encoded transaction signature with prefix
+    optional bytes sig_op_contents = 2;     // operation_bytes + signed operation_bytes
+    optional string operation_hash = 3;     // b58 encoded hashed operation contents with prefix
 }


### PR DESCRIPTION
* added curve type option
* returning public key as a b58 encoded string with prefix

@prusnak According to http://doc.tzalpha.net/api/p2p.html#public-key-determined-from-data-8-bit-tag Tezos supports P256 curve. @matejcik told me that trezor supports this curve, but I found only `nist256p1`.  Are they the same?