### PR TITLE
Lowering dash minfee

### DIFF
--- a/defs/coins/dash.json
+++ b/defs/coins/dash.json
@@ -9,7 +9,7 @@
   "address_type": 76,
   "address_type_p2sh": 16,
   "maxfee_kb": 100000,
-  "minfee_kb": 10000,
+  "minfee_kb": 1000,
   "signed_message_header": "DarkCoin Signed Message:\n",
   "hash_genesis_block": "00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6",
   "xprv_magic": 50221816,


### PR DESCRIPTION
Apparently Dash itself returns fee 220

I am leaving this as 1000 as wallet might have more issues with fee < 1sat/B (fee here is satoshi/kB, daemon returns BTC/kB on fee estimation, gui has sat/B)