### PR TITLE
Add support for AtheiosChain (ATH)

### DIFF
--- a/defs/ethereum/networks.json
+++ b/defs/ethereum/networks.json
@@ -166,5 +166,13 @@
     "name": "Pirl",
     "rskip60": false,
     "url": "https://pirl.io"
+  },
+  {
+    "chain_id": 1620,
+    "slip44": 1620,
+    "shortcut": "ATH",
+    "name": "Atheios",
+    "rskip60": false,
+    "url": "https://atheios.com"
   }
 ]


### PR DESCRIPTION
EIP-155 is now properly working with Atheios!! Tested personally on the Ledger Nano S

homepage           : https://atheios.com
block explorer     : http://explorer.atheios.com | https://scan.atheios.com
network statistics : http://stats.atheios.com
slip0044 index     : 1620
chainId            : 1620