### PR TITLE
Monero: support for lite protocol added

### DIFF
--- a/protob/messages-monero.proto
+++ b/protob/messages-monero.proto
@@ -408,6 +408,45 @@ message MoneroKeyImageSyncRequest {
 }
 
 /**
+ * Request: Lite protocol initialization request
+ * @start
+ * @next MoneroLiteInitAck
+ */
+message MoneroLiteInitRequest {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional uint32 network_type = 3;       // Main-net / testnet / stagenet
+}
+
+/**
+ * Request: Lite protocol initialization response
+ * @end
+ */
+message MoneroLiteInitAck {
+	
+}
+
+/**
+ * Request: Lite protocol generic request
+ * @start
+ * @next MoneroLiteAck
+ */
+message MoneroLiteRequest {
+    optional uint32 ins = 1;
+    optional uint32 p1 = 2;
+    optional uint32 p2 = 3;
+    optional bytes data = 4;
+}
+
+/**
+ * Request: Lite protocol generic response
+ * @end
+ */
+message MoneroLiteAck {
+    optional uint64 sw = 1;
+    optional bytes data = 2;
+}
+
+/**
  * Request: Universal Monero protocol implementation diagnosis request.
  * @start
  * @next DebugMoneroDiagAck

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -211,6 +211,10 @@ enum MessageType {
     MessageType_MoneroAddress = 531 [(wire_out) = true];
     MessageType_MoneroGetWatchKey = 532 [(wire_in) = true];
     MessageType_MoneroWatchKey = 533 [(wire_out) = true];
+    MessageType_MoneroLiteInitRequest = 540 [(wire_in) = true];
+    MessageType_MoneroLiteInitAck = 541 [(wire_out) = true];
+    MessageType_MoneroLiteRequest = 542 [(wire_in) = true];
+    MessageType_MoneroLiteAck = 543 [(wire_out) = true];
     MessageType_DebugMoneroDiagRequest = 536 [(wire_in) = true];
     MessageType_DebugMoneroDiagAck = 537 [(wire_out) = true];
 }


### PR DESCRIPTION
I've implemented the very simple fallback protocol for the Monero wallet (lite protocol / proxy protocol) which is already implemented in the monero C++ codebase.

Should there be some problem with the merge of the high level protocol this could be nice fall back. 