### PR TITLE
xmr: add integrated addresses indicator

### DIFF
--- a/protob/messages-monero.proto
+++ b/protob/messages-monero.proto
@@ -140,6 +140,7 @@ message MoneroTransactionInitRequest {
         optional bytes exp_tx_prefix_hash = 12;
         repeated bytes use_tx_keys = 13;
         optional MoneroTransactionRsigData rsig_data = 14;
+        repeated uint32 integrated_indices = 15;
     }
 }
 


### PR DESCRIPTION
An integrated address is an address which contains payment ID. Some markets / exchanges are using integrated addresses as it is less prone to errors (payment ID is checksummed).

If a user enters the integrated address as a recipient of transaction it is better to display it in the integrated form, otherwise it is difficult to verify it when confirming the transaction.