### PR TITLE
Re-enable Koto for webwallet

### DIFF
--- a/defs/support.json
+++ b/defs/support.json
@@ -1712,6 +1712,7 @@
       "bitcoin:DOGE": true,
       "bitcoin:FJC": true,
       "bitcoin:GRS": true,
+      "bitcoin:KOTO": true,
       "bitcoin:LTC": true,
       "bitcoin:MONA": true,
       "bitcoin:TAZ": true,


### PR DESCRIPTION
Would you enable Koto for webwallet. Koto was enabled in previous support.json.