### PR TITLE
Change EOSC Chainid

### DIFF
--- a/defs/ethereum/networks.json
+++ b/defs/ethereum/networks.json
@@ -55,7 +55,7 @@
   },
   {
     "chain": "eosc",
-    "chain_id": 20,
+    "chain_id": 2018,
     "slip44": 2018,
     "shortcut": "EOSC",
     "name": "EOS Classic",


### PR DESCRIPTION
EOS Classic is going to swtich the mainnet according to this announcement

https://medium.com/@eoscio/closing-pre-mainnet-and-mainnet-upgrade-announcement-3c0b9ac8912a

Chainid value will be changed to 2018