### PR TITLE
Tezos: add support for staking

### DIFF
--- a/protob/messages-tezos.proto
+++ b/protob/messages-tezos.proto
@@ -133,11 +133,11 @@ message TezosSignedTx {
 }
 
 /**
- * Request: Ask device to sign Tezos delegator operations
+ * Request: Ask device to sign Tezos baker operations
  * @start
- * @next TezosSignedDelegatorOp
+ * @next TezosSignedBakerOp
  */
-message TezosSignDelegatorOp {
+message TezosSignBakerOp {
     repeated uint32 address_n = 1;
     optional bytes magic_byte = 2;
     optional bytes chain_id = 3;
@@ -177,10 +177,10 @@ message TezosSignDelegatorOp {
 }
 
 /**
- * Response: Contains Tezos delegator operation signature
+ * Response: Contains Tezos baker operation signature
  * @end
  */
-message TezosSignedDelegatorOp {
+message TezosSignedBakerOp {
     optional string signature = 1;
 }
 
@@ -189,6 +189,6 @@ message TezosSignedDelegatorOp {
  * @start
  * @next Success
  */
-message TezosControlStaking {
-    optional bool staking = 1;
+message TezosControlBaking {
+    optional bool baking = 1;
 }

--- a/protob/messages-tezos.proto
+++ b/protob/messages-tezos.proto
@@ -139,10 +139,11 @@ message TezosSignedTx {
  */
 message TezosSignBakerOp {
     repeated uint32 address_n = 1;
-    optional bytes magic_byte = 2;
-    optional bytes chain_id = 3;
-    optional TezosEndorsement endorsement = 4;
-    optional TezosBlockHeader block_header = 5;
+    //force set the magic byte
+    //optional bytes magic_byte = 2;
+    optional bytes chain_id = 2;
+    optional TezosEndorsement endorsement = 3;
+    optional TezosBlockHeader block_header = 4;
 
     /**
      * Structure representing endorsement
@@ -150,8 +151,9 @@ message TezosSignBakerOp {
      */
     message TezosEndorsement {
         optional bytes branch = 1;
-        optional uint64 tag = 2;
-        optional uint64 level = 3;
+        //force set the tag
+        //optional uint64 tag = 2;
+        optional uint64 level = 2;
     }
 
     /**

--- a/protob/messages-tezos.proto
+++ b/protob/messages-tezos.proto
@@ -131,3 +131,64 @@ message TezosSignedTx {
     optional bytes sig_op_contents = 2;     // operation_bytes + signed operation_bytes
     optional string operation_hash = 3;     // b58 encoded hashed operation contents with prefix
 }
+
+/**
+ * Request: Ask device to sign Tezos delegator operations
+ * @start
+ * @next TezosSignedDelegatorOp
+ */
+message TezosSignDelegatorOp {
+    repeated uint32 address_n = 1;
+    optional bytes magic_byte = 2;
+    optional bytes chain_id = 3;
+    optional TezosEndorsement endorsement = 4;
+    optional TezosBlockHeader block_header = 5;
+
+    /**
+     * Structure representing endorsement
+     * see https://tezos.gitlab.io/master/api/p2p.html#
+     */
+    message TezosEndorsement {
+        optional bytes branch = 1;
+        optional uint64 tag = 2;
+        optional uint64 level = 3;
+    }
+
+    /**
+     * Structure representing block header
+     * see https://tezos.gitlab.io/master/api/p2p.html#
+     */
+    message TezosBlockHeader {
+        optional uint64 level = 1;
+        optional uint64 proto = 2;
+        optional bytes predecessor = 3;
+        optional uint64 timestamp = 4;
+        optional uint64 validation_pass = 5;
+        optional bytes operations_hash = 6;
+        optional uint64 bytes_in_field_fitness = 7;
+        optional uint64 bytes_in_next_field = 8;
+        optional bytes fitness = 9;
+        optional bytes context = 10;
+        optional uint64 priority = 11;
+        optional bytes proof_of_work_nonce = 12;
+        optional bool presence_of_field_seed_nonce_hash = 13;
+        optional bytes seed_nonce_hash = 14;
+    }
+}
+
+/**
+ * Response: Contains Tezos delegator operation signature
+ * @end
+ */
+message TezosSignedDelegatorOp {
+    optional string signature = 1;
+}
+
+/**
+ * Request: Activate/Deactivate staking mode
+ * @start
+ * @next Success
+ */
+message TezosControlStaking {
+    optional bool staking = 1;
+}

--- a/protob/messages-tezos.proto
+++ b/protob/messages-tezos.proto
@@ -192,5 +192,4 @@ message TezosSignedBakerOp {
  * @next Success
  */
 message TezosControlBaking {
-    optional bool baking = 1;
 }

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -141,9 +141,9 @@ enum MessageType {
     MessageType_TezosSignedTx = 153 [(wire_out) = true];
     MessageType_TezosGetPublicKey = 154 [(wire_in) = true];
     MessageType_TezosPublicKey = 155 [(wire_out) = true];
-    MessageType_TezosSignDelegatorOp = 156 [(wire_in) = true];
-    MessageType_TezosSignedDelegatorOp = 157 [(wire_out) = true];
-    MessageType_TezosControlStaking = 158 [(wire_in) = true];
+    MessageType_TezosSignBakerOp = 156 [(wire_in) = true];
+    MessageType_TezosSignedBakerOp = 157 [(wire_out) = true];
+    MessageType_TezosControlBaking = 158 [(wire_in) = true];
 
     // Stellar
     MessageType_StellarSignTx = 202 [(wire_in) = true];

--- a/protob/messages.proto
+++ b/protob/messages.proto
@@ -141,6 +141,9 @@ enum MessageType {
     MessageType_TezosSignedTx = 153 [(wire_out) = true];
     MessageType_TezosGetPublicKey = 154 [(wire_in) = true];
     MessageType_TezosPublicKey = 155 [(wire_out) = true];
+    MessageType_TezosSignDelegatorOp = 156 [(wire_in) = true];
+    MessageType_TezosSignedDelegatorOp = 157 [(wire_out) = true];
+    MessageType_TezosControlStaking = 158 [(wire_in) = true];
 
     // Stellar
     MessageType_StellarSignTx = 202 [(wire_in) = true];


### PR DESCRIPTION
This adds new protobuf messages to Tezos for signing staking operations such as endorsmenets and freshly baked block headers.

We are also ready to create PRs to repositories trezor-core and python-trezor