### PR TITLE
Dash DIP2 transactions support

### DIFF
--- a/protob/messages-bitcoin.proto
+++ b/protob/messages-bitcoin.proto
@@ -134,6 +134,7 @@ message SignTx {
     optional uint32 version_group_id = 8;               // only for Zcash, nVersionGroupId when overwintered is set
     optional uint32 timestamp = 9;                      // only for Capricoin, transaction timestamp
     optional uint32 branch_id = 10;                     // only for Zcash, BRANCH_ID when overwintered is set
+    optional uint32 extra_data_len = 11 [default=0];	// additional tx payload, only for Dash
 }
 
 /**


### PR DESCRIPTION
Dash introduces special transactions as presented in DIP 2 : https://github.com/dashpay/dips/blob/master/dip-0002.md. This changes the transactions such that some transactions will have a variable size payload after the locktime field. 

To create DIP2 transaction in Trezor we need to to add optional `extra_data_len` field in SignTx message.