### PR TITLE
add Komodo backend

### DIFF
--- a/defs/bitcoin/komodo.json
+++ b/defs/bitcoin/komodo.json
@@ -32,7 +32,9 @@
   "uri_prefix": "komodo",
   "min_address_length": 27,
   "max_address_length": 34,
-  "bitcore": [],
+  "bitcore": [  
+    "https://api.kmd.dev"
+  ],
   "blockbook": [],
   "cooldown": 100
 }


### PR DESCRIPTION
https://api.kmd.dev was setup dedicated for trezor and has an /api endpoint