### PR TITLE
xmr: add version fields to check for protocol compatibility

### DIFF
--- a/protob/messages-monero.proto
+++ b/protob/messages-monero.proto
@@ -138,6 +138,8 @@ message MoneroTransactionInitRequest {
         optional MoneroTransactionRsigData rsig_data = 11;
         repeated uint32 integrated_indices = 12;
         optional uint32 client_version = 13;  // connected client version
+        optional uint32 hard_fork = 14;       // transaction hard fork number
+        optional bytes monero_version = 15;   // monero software version
     }
 }
 


### PR DESCRIPTION
- Safe-check in case hard fork number increases without Trezor being patched to that version. 
- Same for monero software version - if major version update is detected, T may warn to do only in own risk without updating Trezor firmware compatible with new versions

Semantics of the versions sent:
- `client_version` is the Trezor client version implemented in Monero codebase. Trezor can adapt the protocol according to this number (protocol version negotiation). 
   - Required for transition periods when some clients still did not update and some did. 
   - Low versions could be unsupported - Trezor shows an error

- `hard_fork` for checking the blockchain/transaction rules. 
   - Trezor should always block or at least display prompt dialog "On your own risk" if the hard fork is higher than implemented in Trezor. Changed rules could cause invalid transaction or funds loss in the worst case.

- `monero_version` is the Monero client version string. This can change independently on `client_version` as the client code can be outdated while monero version changes. 
    - Major version updates should also raise errors / warning prompts.