### PR TITLE
Added RVN to wallets.json

### DIFF
--- a/defs/wallets.json
+++ b/defs/wallets.json
@@ -60,5 +60,8 @@
     },
     "bitcoin:QTUM": {
         "Qtum-Electrum": "https://github.com/qtumproject/qtum-electrum"
+    },
+    "bitcoin:RVN": {
+        "Electrum-RVN": "https://github.com/traysi/electrum-raven"
     }
 }


### PR DESCRIPTION
Pavol requested we add a link to our electrum github. It has been tested to work well with Trezor.